### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sync:
 ```js
 const { randomSync } = require('pure-random-number')
 
-const n = randomNumber(10, 30)
+const n = randomSync(10, 30)
 console.log('Secure unbiased random number:', n)
 ```
 


### PR DESCRIPTION
This PR fixes a quick typo in the REAMDE, `randomNumber` should be `randomSync`.

```
> const { randomSync } = require('pure-random-number')
undefined
> const n = randomSync(10, 30)
undefined
> console.log('Secure unbiased random number:', n)
Secure unbiased random number: 11
undefined
```

---

(Thanks for this repo, I'm glad I checked the forks before doing exactly what you've done. 😅)